### PR TITLE
Clear initial scanout buffer on creation

### DIFF
--- a/src/armsoc_driver.c
+++ b/src/armsoc_driver.c
@@ -1016,6 +1016,7 @@ ARMSOCScreenInit(SCREEN_INIT_ARGS_DECL)
 	pARMSOC->scanout = armsoc_bo_new_with_dim(pARMSOC->dev, pScrn->virtualX,
 			pScrn->virtualY, depth, pScrn->bitsPerPixel,
 			ARMSOC_BO_SCANOUT);
+	armsoc_bo_clear(pARMSOC->scanout);
 	if (!pARMSOC->scanout) {
 		ERROR_MSG("Cannot allocate scanout buffer\n");
 		goto fail1;

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -281,7 +281,6 @@ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
 
 	TRACE_ENTER();
 
-	armsoc_bo_clear(pARMSOC->scanout);
 	fb_id = armsoc_bo_get_fb(pARMSOC->scanout);
 
 	if (fb_id == 0) {


### PR DESCRIPTION
Not in every set mode.
Otherwise you get mad flickering when you have other DRI activities going on.